### PR TITLE
Feature/Comment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,15 +19,26 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+
+	// 스프링 시큐리티
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	testImplementation 'org.springframework.security:spring-security-test'
+
+	// JWT
+//	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+//	implementation 'commons-codec:commons-codec:1.15'
+//	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+//	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+//	compileOnly 'com.auth0:java-jwt:4.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/avengers/controller/CommentController.java
+++ b/src/main/java/com/sparta/avengers/controller/CommentController.java
@@ -1,0 +1,37 @@
+package com.sparta.avengers.controller;
+
+import com.sparta.avengers.dto.request.CommentRequestDto;
+import com.sparta.avengers.dto.response.ResponseDto;
+import com.sparta.avengers.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RequiredArgsConstructor
+@Validated
+@RestController
+public class CommentController {
+    private final CommentService commentService;
+
+    @RequestMapping(value = "/api/comment/{id}", method = RequestMethod.GET)
+    public ResponseDto<?> getCommentsByBoard(@PathVariable Long id) {
+        return commentService.getCommentsByBoard(id);
+    }
+
+    @RequestMapping(value = "/api/auth/comment", method = RequestMethod.POST)
+    public ResponseDto<?> createComment(@RequestBody CommentRequestDto commentRequestDto, HttpServletRequest request) {
+        return commentService.createComment(commentRequestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/comment/{id}", method = RequestMethod.PUT)
+    public ResponseDto<?> updateComment(@PathVariable Long id, @RequestBody CommentRequestDto commentRequestDto, HttpServletRequest request) {
+        return commentService.updateComment(id, commentRequestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/comment/{id}", method = RequestMethod.DELETE)
+    public ResponseDto<?> deleteComment(@PathVariable Long id, HttpServletRequest request) {
+        return commentService.deleteComment(id, request);
+    }
+}

--- a/src/main/java/com/sparta/avengers/controller/NestedCommentController.java
+++ b/src/main/java/com/sparta/avengers/controller/NestedCommentController.java
@@ -1,0 +1,39 @@
+package com.sparta.avengers.controller;
+
+import com.sparta.avengers.dto.request.NestedCommentRequestDto;
+import com.sparta.avengers.dto.response.ResponseDto;
+import com.sparta.avengers.service.NestedCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RequiredArgsConstructor
+@Validated
+@RestController
+public class NestedCommentController {
+    private final NestedCommentService nestedCommentService;
+
+    @RequestMapping(value = "/api/nestedcomment/{id}", method = RequestMethod.GET)
+    public ResponseDto<?> getNestedCommentsByComment(@PathVariable Long id) {
+        return nestedCommentService.getNestedCommentsByComment(id);
+    }
+
+    @RequestMapping(value = "/api/auth/nestedcomment", method = RequestMethod.POST)
+    public ResponseDto<?> createNestedComment(@RequestBody NestedCommentRequestDto nestedCommentRequestDto,
+                                              HttpServletRequest request) {
+        return nestedCommentService.createNestedComment(nestedCommentRequestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/nestedcomment/{id}", method = RequestMethod.PUT)
+    public ResponseDto<?> updateNestedComment(@PathVariable Long id,
+                                              @RequestBody NestedCommentRequestDto nestedCommentRequestDto, HttpServletRequest request) {
+        return nestedCommentService.updateNestedComment(id, nestedCommentRequestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/nestedcomment/{id}", method = RequestMethod.DELETE)
+    public ResponseDto<?> deleteNestedComment(@PathVariable Long id, HttpServletRequest request) {
+        return nestedCommentService.deleteNestedComment(id, request);
+    }
+}

--- a/src/main/java/com/sparta/avengers/dto/request/CommentRequestDto.java
+++ b/src/main/java/com/sparta/avengers/dto/request/CommentRequestDto.java
@@ -1,0 +1,13 @@
+package com.sparta.avengers.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CommentRequestDto {
+    private Long boardId;
+    private String content;
+}

--- a/src/main/java/com/sparta/avengers/dto/request/NestedCommentRequestDto.java
+++ b/src/main/java/com/sparta/avengers/dto/request/NestedCommentRequestDto.java
@@ -1,0 +1,13 @@
+package com.sparta.avengers.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class NestedCommentRequestDto {
+    private Long commentId;
+    private String content;
+}

--- a/src/main/java/com/sparta/avengers/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/sparta/avengers/dto/response/CommentResponseDto.java
@@ -1,0 +1,22 @@
+package com.sparta.avengers.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponseDto {
+    private long id;
+    private String writer;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private List<NestedCommentResponseDto> nestedCommentResponseDtoList;
+}

--- a/src/main/java/com/sparta/avengers/dto/response/NestedCommentResponseDto.java
+++ b/src/main/java/com/sparta/avengers/dto/response/NestedCommentResponseDto.java
@@ -1,0 +1,20 @@
+package com.sparta.avengers.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NestedCommentResponseDto {
+    private Long id;
+    private String writer;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/sparta/avengers/dto/response/ResponseDto.java
+++ b/src/main/java/com/sparta/avengers/dto/response/ResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.avengers.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResponseDto<T> {
+    private boolean success;
+    private T data;
+    private Error error;
+
+    public static <T> ResponseDto<T> success(T data) {
+        return new ResponseDto<>(true, data, null);
+    }
+
+    public static <T> ResponseDto<T> fail(String code, String message) {
+        return new ResponseDto<>(false, null, new Error(code, message));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class Error {
+        private String code;
+        private String message;
+    }
+
+}

--- a/src/main/java/com/sparta/avengers/model/Comment.java
+++ b/src/main/java/com/sparta/avengers/model/Comment.java
@@ -1,0 +1,45 @@
+package com.sparta.avengers.model;
+
+import com.sparta.avengers.dto.request.CommentRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Comment extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "board_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Board board;
+
+    @Column(nullable = false)
+    private String content;
+
+    @OneToMany(mappedBy ="comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<NestedComment> nestedComments;
+
+    public void update(CommentRequestDto commentRequestDto) {
+        this.content = commentRequestDto.getContent();
+    }
+
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+
+}

--- a/src/main/java/com/sparta/avengers/model/NestedComment.java
+++ b/src/main/java/com/sparta/avengers/model/NestedComment.java
@@ -1,0 +1,45 @@
+package com.sparta.avengers.model;
+
+import com.sparta.avengers.dto.request.NestedCommentRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class NestedComment extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "board_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Board board;
+
+    @JoinColumn(name = "comment_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment comment;
+
+    @Column(nullable = false)
+    private String content;
+
+
+    public void update(NestedCommentRequestDto nestedcommentRequestDto) {
+        this.content = nestedcommentRequestDto.getContent();
+    }
+
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+}

--- a/src/main/java/com/sparta/avengers/model/Timestamped.java
+++ b/src/main/java/com/sparta/avengers/model/Timestamped.java
@@ -1,0 +1,22 @@
+package com.sparta.avengers.model;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/sparta/avengers/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/avengers/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.avengers.repository;
+
+import com.sparta.avengers.model.Board;
+import com.sparta.avengers.model.Comment;
+import com.sparta.avengers.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByBoard(Board board);
+    List<Comment> findByMember(Member member);
+
+    void deleteByBoardId(Long id);
+}

--- a/src/main/java/com/sparta/avengers/repository/NestedCommentRepository.java
+++ b/src/main/java/com/sparta/avengers/repository/NestedCommentRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.avengers.repository;
+
+import com.sparta.avengers.model.Comment;
+import com.sparta.avengers.model.Member;
+import com.sparta.avengers.model.NestedComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NestedCommentRepository extends JpaRepository<NestedComment, Long> {
+    List<NestedComment> findAllByComment(Comment comment);
+    List<NestedComment> findAllByMember(Member member);
+
+    void deleteByBoardId(Long id);
+}

--- a/src/main/java/com/sparta/avengers/service/CommentService.java
+++ b/src/main/java/com/sparta/avengers/service/CommentService.java
@@ -1,0 +1,180 @@
+package com.sparta.avengers.service;
+
+import com.sparta.avengers.dto.request.CommentRequestDto;
+import com.sparta.avengers.dto.response.CommentResponseDto;
+import com.sparta.avengers.dto.response.NestedCommentResponseDto;
+import com.sparta.avengers.dto.response.ResponseDto;
+import com.sparta.avengers.model.Board;
+import com.sparta.avengers.model.Comment;
+import com.sparta.avengers.model.NestedComment;
+import com.sparta.avengers.repository.CommentRepository;
+import com.sparta.avengers.repository.NestedCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final NestedCommentRepository nestedCommentRepository;
+    // tokenProvider 선언
+    // boardService 선언
+
+
+    @Transactional(readOnly = true)
+    public ResponseDto<?> getCommentsByBoard(Long boardId) {
+        Board board = boardService.isPresentBoard(boardId); // 메서드 이름 확인
+        if (board == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 입니다.");
+        }
+
+        List<Comment> commentList = commentRepository.findAllByBoard(board);
+        List<CommentResponseDto> commentResponseDtoList = new ArrayList<>();
+
+        for (Comment comment : commentList) {
+            List<NestedComment> nestedCommentList = nestedCommentRepository.findAllByComment(comment);
+            List<NestedCommentResponseDto> nestedCommentResponseDtoList = new ArrayList<>();
+
+            for (NestedComment nestedComment : nestedCommentList) {
+                nestedCommentResponseDtoList.add(
+                        NestedCommentResponseDto.builder()
+                                .id(nestedComment.getId())
+                                .writer(nestedComment.getMember().getName())
+                                .content(nestedComment.getContent())
+                                .createdAt(nestedComment.getCreatedAt())
+                                .modifiedAt(nestedComment.getModifiedAt())
+                                .build()
+                );
+            }
+
+            commentResponseDtoList.add(
+                    CommentResponseDto.builder()
+                            .id(comment.getId())
+                            .writer(comment.getMember().getName())
+                            .content(comment.getContent())
+                            .createdAt(comment.getCreatedAt())
+                            .modifiedAt(comment.getModifiedAt())
+                            .nestedCommentResponseDtoList(nestedCommentResponseDtoList)
+                            .build()
+            );
+        }
+
+        return ResponseDto.success(commentResponseDtoList);
+    }
+
+    @Transactional
+    public ResponseDto<?> createComment(CommentRequestDto commentRequestDto, HttpServletRequest request) {
+
+        // 토큰 및 권한 확인 작성칸
+
+        Member member = validateMember(request);
+        if (member == null) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Board board = boardService.isPresentBoard(commentRequestDto.getBoardId()); // 메서드 이름 확인
+        if (board == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 입니다.");
+        }
+
+        Comment comment = Comment.builder()
+                .member(member)
+                .board(board)
+                .content(commentRequestDto.getContent())
+                .build();
+        commentRepository.save(comment);
+        return ResponseDto.success(
+                CommentResponseDto.builder()
+                        .id(comment.getId())
+                        .writer(comment.getMember().getName())
+                        .content(comment.getContent())
+                        .createdAt(comment.getCreatedAt())
+                        .modifiedAt(comment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ResponseDto<?> updateComment(Long id, CommentRequestDto commentRequestDto, HttpServletRequest request) {
+
+        // 토큰 및 권한 확인 작성칸
+
+        Member member = validateMember(request);
+        if (member == null) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Board board = boardService.isPresentBoard(commentRequestDto.getBoardId()); // 메서드 이름 확인
+        if (board == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 입니다.");
+        }
+        
+        Comment comment = isPresentComment(id);
+        if (comment == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 입니다.");
+        }
+        
+        if (comment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+        
+        comment.update(commentRequestDto);
+        return ResponseDto.success(
+                CommentResponseDto.builder()
+                        .id(comment.getId())
+                        .writer(comment.getMember().getName())
+                        .content(comment.getContent())
+                        .createdAt(comment.getCreatedAt())
+                        .modifiedAt(comment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ResponseDto<?> deleteComment(Long id, HttpServletRequest request) {
+
+        // 토큰 및 권한 확인 작성칸
+
+        Member member = validateMember(request);
+        if (member == null) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Comment comment = isPresentComment(id);
+        if (comment == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 입니다.");
+        }
+
+        if (comment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 삭제할 수 있습니다.");
+        }
+
+        commentRepository.delete(comment);
+        return ResponseDto.success("success");
+    }
+
+
+    // 멤버 인증
+    @Transactional
+    public Member validateMember(HttpServletRequest request) {
+        if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+            return null;
+        }
+        return tokenProvider.getMemberFromAuthentication();
+    }
+
+    // 해당 id 댓글 유무 확인
+    @Transactional(readOnly = true)
+    public Comment isPresentComment(Long id) {
+        Optional<Comment> optionalComment = commentRepository.findById(id);
+        return optionalComment.orElse(null);
+    }
+}

--- a/src/main/java/com/sparta/avengers/service/NestedCommentService.java
+++ b/src/main/java/com/sparta/avengers/service/NestedCommentService.java
@@ -1,0 +1,160 @@
+package com.sparta.avengers.service;
+
+
+import com.sparta.avengers.dto.request.NestedCommentRequestDto;
+import com.sparta.avengers.dto.response.NestedCommentResponseDto;
+import com.sparta.avengers.dto.response.ResponseDto;
+import com.sparta.avengers.model.Comment;
+import com.sparta.avengers.model.NestedComment;
+import com.sparta.avengers.repository.NestedCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NestedCommentService {
+    private final NestedCommentRepository nestedCommentRepository;
+    private final CommentService commentService;
+    // tokenProvider 선언
+    // boardService 선언
+
+    @Transactional(readOnly = true)
+    public ResponseDto<?> getNestedCommentsByComment(Long commentId) {
+        Comment comment = commentService.isPresentComment(commentId);
+        if (comment == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 입니다.");
+        }
+
+        List<NestedComment> nestedCommentList = nestedCommentRepository.findAllByComment(comment);
+        List<NestedCommentResponseDto> nestedCommentResponseDtoList = new ArrayList<>();
+
+        for (NestedComment nestedComment : nestedCommentList) {
+            nestedCommentResponseDtoList.add(
+              NestedCommentResponseDto.builder()
+                      .id(nestedComment.getId())
+                      .writer(nestedComment.getMember().getName())
+                      .content(nestedComment.getContent())
+                      .createdAt(nestedComment.getCreatedAt())
+                      .modifiedAt(nestedComment.getModifiedAt())
+                      .build()
+            );
+        }
+        return ResponseDto.success(nestedCommentResponseDtoList);
+    }
+
+    @Transactional
+    public ResponseDto<?> createNestedComment(NestedCommentRequestDto nestedCommentRequestDto, HttpServletRequest request) {
+
+        // 토큰 및 권한 확인 작성칸
+
+        Member member = validateMember(request);
+        if (member == null) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Comment comment = commentService.isPresentComment(nestedCommentRequestDto.getCommentId());
+        if (comment == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 입니다.");
+        }
+
+        Board board = boardService.isPresentBoard(comment.getBoard().getId()); // 메서드 이름 확인
+
+        NestedComment nestedComment = NestedComment.builder()
+                .member(member)
+                .board(board)
+                .comment(comment)
+                .content(nestedCommentRequestDto.getContent())
+                .build();
+        nestedCommentRepository.save(nestedComment);
+        return ResponseDto.success(
+                NestedCommentResponseDto.builder()
+                        .id(nestedComment.getId())
+                        .writer(nestedComment.getMember().getName())
+                        .content(nestedComment.getContent())
+                        .createdAt(nestedComment.getCreatedAt())
+                        .modifiedAt(nestedComment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ResponseDto<?> updateNestedComment(Long id, NestedCommentRequestDto nestedCommentRequestDto, HttpServletRequest request) {
+
+        // 토큰 및 권한 확인 작성칸
+
+        Member member = validateMember(request);
+        if (member == null) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Comment comment = commentService.isPresentComment(nestedCommentRequestDto.getCommentId());
+        if (comment == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 입니다.");
+        }
+
+        NestedComment nestedComment = isPresentNestedComment(id);
+        if (nestedComment == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 입니다.");
+        }
+
+        if (nestedComment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+
+        nestedComment.update(nestedCommentRequestDto);
+        return ResponseDto.success(
+                NestedCommentResponseDto.builder()
+                        .id(nestedComment.getId())
+                        .writer(nestedComment.getMember().getName())
+                        .content(nestedComment.getContent())
+                        .createdAt(nestedComment.getCreatedAt())
+                        .modifiedAt(nestedComment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ResponseDto<?> deleteNestedComment(Long id, HttpServletRequest request) {
+
+        // 토큰 및 권한 확인 작성칸
+
+        Member member = validateMember(request);
+        if (member == null) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        NestedComment nestedComment = isPresentNestedComment(id);
+        if (nestedComment == null) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 입니다.");
+        }
+
+        if (nestedComment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 삭제할 수 있습니다.");
+        }
+
+        nestedCommentRepository.delete(nestedComment);
+        return ResponseDto.success("success");
+    }
+
+    // 멤버 인증
+    @Transactional
+    public Member validateMember(HttpServletRequest request) {
+        if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+            return null;
+        }
+        return tokenProvider.getMemberFromAuthentication();
+    }
+
+    // 해당 id 댓글 유무 확인
+    @Transactional(readOnly = true)
+    public NestedComment isPresentNestedComment(Long id) {
+        Optional<NestedComment> optionalNestedComment = nestedCommentRepository.findById(id);
+        return optionalNestedComment.orElse(null);
+    }
+}


### PR DESCRIPTION
# 기능 02. 대댓글

## ✄ 요구사항
`200` AccessToken이 있고, 유효한 Token일 때(== 로그인 상태일 때)만 댓글/대댓글 작성 가능하게 하기
댓글 리스트 response할 때 대댓글 리스트도 모두 포함해서 보여주기
`Exception` AccessToken이 없거나, 유효하지 않은 Token일 때 ‘로그인이 필요합니다.’를 200 정상 응답으로 나타내기

> **API 종류**
1.  대댓글 목록 조회 API
- AccessToken이 없어도 댓글 목록 조회가 가능하도록 하기
- 조회하는 게시글에 작성된 모든 댓글을 response에 포함하기
2. 대댓글 작성 API
- AccessToken이 있고, 유효한 Token일 때만 댓글 작성이 가능하도록 하기
3. 대댓글 수정 API
- AccessToken이 있고, 유효한 Token이면서 해당 사용자가 작성한 댓글만 수정 가능하도록 하기
4. 대댓글 삭제 API
- AccessToken이 있고, 유효한 Token이면서 해당  사용자가 작성한 댓글만 삭제 가능하도록 하기

##  ✄ 진행상태

### 구성
<img width="294" alt="스크린샷 2022-08-31 오후 10 15 54" src="https://user-images.githubusercontent.com/110372162/187687440-91f3068d-16ca-42ca-aa5a-57c3e0ddd5af.png">

- 댓글 조회, 생성, 수정, 삭제
- 대댓글 조회, 생성, 수정, 삭제
- 댓글 목록 조회할 때는 대댓글 목록도 같이 조회
- 댓글/대댓글 생성, 수정, 삭제는 회원만 가능 ( 그 중 수정, 삭제는 해당 작성자만 가능 )
- 댓글이 삭제되면 그에 해당하는 대댓글들도 함께 삭제

### ‼️ 추가 해야할 부분
- Member( _댓글 작성자 및 회원_ ), Board( _댓글이 달릴 게시글_ ) 추가 필요
- 좋아요 기능 추가 필요
- 토큰 발급 구현 완료되면 토큰과 권한 체크하는 코드 추가 필요


