### PR TITLE
기능 3 : 이미지 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,13 +21,29 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+
+	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'io.findify:s3mock_2.12:0.2.6'
+
+
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
+
+
+	implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.290')
+	implementation 'com.amazonaws:aws-java-sdk-s3'
+//	implementation 'org.springframework.cloud:spring-cloud-starter-aws-jdbc:2.2.6.RELEASE'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/avengers/config/S3Config.java
+++ b/src/main/java/com/sparta/avengers/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.sparta.avengers.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+
+    @Bean
+    public AmazonS3Client amazonS3Client(){
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/sparta/avengers/controller/S3Controller.java
+++ b/src/main/java/com/sparta/avengers/controller/S3Controller.java
@@ -1,0 +1,38 @@
+package com.sparta.avengers.controller;
+
+import com.sparta.avengers.dto.ResponseDto;
+import com.sparta.avengers.service.S3UploaderService;
+import com.sparta.avengers.util.ImageScheduler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+public class S3Controller {
+    private final S3UploaderService s3Uploader;
+    private final ImageScheduler imageScheduler; // 공통 스케줄러 추가 후 삭제
+
+    //다중이미지 받을 떄
+    //List<MultipartFile> files
+
+    @PostMapping("/api/member/image")
+    public ResponseDto<?> imageUpload(@RequestParam("image") MultipartFile multipartFile){
+
+        return s3Uploader.getResponseDto(multipartFile);
+
+    }
+
+    @GetMapping("/api/member/test")
+    public void test(){
+        try{
+            imageScheduler.deleteImage();
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+
+    }
+}

--- a/src/main/java/com/sparta/avengers/dto/ImageResponseDto.java
+++ b/src/main/java/com/sparta/avengers/dto/ImageResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.avengers.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class ImageResponseDto {
+    private String imageUrl;
+
+    public ImageResponseDto(String imageUrl){
+        this.imageUrl = imageUrl;
+
+    }
+}

--- a/src/main/java/com/sparta/avengers/dto/ResponseDto.java
+++ b/src/main/java/com/sparta/avengers/dto/ResponseDto.java
@@ -1,0 +1,29 @@
+package com.sparta.avengers.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResponseDto<T> {
+    private boolean success;
+    private T data;
+    private Error error;
+
+    public static <T> ResponseDto<T> success(T data) {
+        return new ResponseDto<>(true, data, null);
+    }
+
+    public static <T> ResponseDto<T> fail(String code, String message) {
+        return new ResponseDto<>(false, null, new Error(code, message));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    static class Error {
+        private String code;
+        private String message;
+    }
+
+}

--- a/src/main/java/com/sparta/avengers/entity/Image.java
+++ b/src/main/java/com/sparta/avengers/entity/Image.java
@@ -1,0 +1,34 @@
+package com.sparta.avengers.entity;
+
+import com.sparta.avengers.validator.URLvalidator;
+import com.sparta.avengers.validator.ValidateObject;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "boardImage")
+public class Image extends Timestamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @Column(nullable = false)
+    private String imgURL;
+
+    public Image(Board board, String imageUrl) {
+        URLvalidator.isValidURL(imageUrl);
+        ValidateObject.postValidate(board);
+        this.board = board;
+        this.imgURL = imageUrl;
+    }
+}

--- a/src/main/java/com/sparta/avengers/entity/Timestamped.java
+++ b/src/main/java/com/sparta/avengers/entity/Timestamped.java
@@ -1,0 +1,23 @@
+package com.sparta.avengers.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Timestamped {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/sparta/avengers/repository/ImageRepository.java
+++ b/src/main/java/com/sparta/avengers/repository/ImageRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.avengers.repository;
+
+
+import com.sparta.avengers.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ImageRepository extends JpaRepository<Image,Long> {
+
+    Optional<Image> findByImgURL(String imgUrl);
+}

--- a/src/main/java/com/sparta/avengers/service/S3UploaderService.java
+++ b/src/main/java/com/sparta/avengers/service/S3UploaderService.java
@@ -1,0 +1,93 @@
+package com.sparta.avengers.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.sparta.avengers.dto.ImageResponseDto;
+import com.sparta.avengers.dto.ResponseDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@Getter
+@RequiredArgsConstructor
+public class S3UploaderService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFiles(MultipartFile multipartFile , String dirName)throws IOException{
+        File uploadFile =convert(multipartFile)
+                .orElseThrow(()->new IllegalArgumentException("ERROR :  MultipartFile -> File convert fail"));
+
+        return upload(uploadFile,dirName);
+    }
+
+    //(S3 서버에 올리면서 로컬에 만든 파일 지우기) 총괄 함수
+    public String upload(File uploadFile, String filepath){
+        String fileName = filepath+"/"+UUID.randomUUID() + uploadFile.getName();
+
+        String uploadImageUrl = putS3(uploadFile,fileName);
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+
+    }
+
+    public ResponseDto<?> getResponseDto(MultipartFile multipartFile) {
+        if(multipartFile.isEmpty()){
+            return ResponseDto.fail("INVALID_FILE", "파일이 유효하지 않습니다.");
+        }
+        try{
+            return ResponseDto.success(new ImageResponseDto(/*s3Uploader.*/uploadFiles(multipartFile, "static")));
+        }catch (Exception e){
+            e.printStackTrace();
+            return ResponseDto.fail("INVALID_FILE", "파일이 유효하지 않습니다.");
+        }
+    }
+
+
+    //S3 업로드
+    public String putS3(File uploadFile, String fileName){
+        amazonS3Client.putObject(new PutObjectRequest(bucket,fileName,uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket,fileName).toString();
+    }
+
+    //로컬에 삭제
+    private void removeNewFile(File targetFile){
+        if(targetFile.delete()){
+            System.out.println("File delete success");
+            return;
+        }
+        System.out.println("file delete fail");
+    }
+
+
+    //로컬에 파일 업로드하기
+    private Optional<File> convert(MultipartFile file) throws IOException{
+        String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        File convertFile = new File(System.getProperty("user.dir") + "/" +now+".jpg" );
+
+        if(convertFile.createNewFile()){
+            try(FileOutputStream fos = new FileOutputStream(convertFile)){
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        System.out.println("변환실패");
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/com/sparta/avengers/util/ImageScheduler.java
+++ b/src/main/java/com/sparta/avengers/util/ImageScheduler.java
@@ -1,0 +1,67 @@
+package com.sparta.avengers.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsRequest;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.sparta.avengers.entity.Image;
+import com.sparta.avengers.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ImageScheduler {
+
+    private final AmazonS3Client amazonS3Client;
+    private final ImageRepository imageRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.static.path}")
+    private String path;
+
+    @Scheduled(cron = "0 0 1 * * *")
+    public void deleteImage() throws InterruptedException{
+
+        //s3Client에 요청 보낼 내용정리
+        ListObjectsRequest listObjectsRequest = new ListObjectsRequest();
+        // 요청결과 객체
+        ObjectListing s3Objects;
+
+
+        listObjectsRequest.setBucketName(bucket);
+        listObjectsRequest.setPrefix("static/");
+        do{
+            s3Objects = amazonS3Client.listObjects( listObjectsRequest);
+            System.out.println(s3Objects.getObjectSummaries());
+
+            for(S3ObjectSummary s3ObjectSummary : s3Objects.getObjectSummaries() ){
+
+                String file = s3ObjectSummary.getKey();
+                //db에 저장된 경로를 만들고, 확인
+                try{
+                    String fileName = (file.split("static/"))[1];
+                    String imgUrl = path+fileName;
+                    Image image = imageRepository.findByImgURL(imgUrl).orElse(null);
+                    //해당경로가 없을 경우, 해당 파일 삭제해야함 s3에서
+                    if(image==null){
+                        deleteS3Image(file);
+                    }
+                }
+                catch (Exception e){
+                }
+            }
+            //1000개 이상일 때 체크;
+            listObjectsRequest.setMarker(s3Objects.getNextMarker());
+        }while(s3Objects.isTruncated());
+    }
+
+    public void deleteS3Image(String file){
+        System.out.println("파일삭제 : "+file);
+        amazonS3Client.deleteObject(bucket,file);
+    }
+}

--- a/src/main/java/com/sparta/avengers/validator/URLvalidator.java
+++ b/src/main/java/com/sparta/avengers/validator/URLvalidator.java
@@ -1,0 +1,21 @@
+package com.sparta.avengers.validator;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class URLvalidator {
+
+    public static boolean isValidURL(String url){
+
+        try{
+            new URL(url).toURI();
+            return true;
+        }catch (URISyntaxException exception){
+            throw new IllegalArgumentException("imgUrl 이 유효하지 않습니다");
+        }catch (MalformedURLException exception){
+            throw new IllegalArgumentException("imgUrl 이 유효하지 않습니다");
+        }
+
+    }
+}

--- a/src/main/java/com/sparta/avengers/validator/ValidateObject.java
+++ b/src/main/java/com/sparta/avengers/validator/ValidateObject.java
@@ -1,0 +1,13 @@
+package com.sparta.avengers.validator;
+
+import com.sparta.avengers.entity.Board;
+
+public class  ValidateObject  {
+
+
+    public static void  postValidate(Board board){
+        if(board.getId()==null || board.getId()<=0){
+            throw new IllegalArgumentException("유효하지 않는 Board Id입니다.");
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,10 @@
+# CloudFormation ? ???? ???? ??? false
+cloud.aws.stack.auto=false
+cloud.aws.s3.bucket=bucket=week5mystorage
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.credentials.access-key=[AKIATJQSBBE7LAOR3NAO]
+cloud.aws.credentials.secret-key=[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]
+cloud.aws.s3.bucket.url=[arn:aws:s3:::week5mystorage]
 
+
+#server.port=8080

--- a/src/test/java/com/sparta/avengers/UnitTest/entity/ImageTest.java
+++ b/src/test/java/com/sparta/avengers/UnitTest/entity/ImageTest.java
@@ -1,0 +1,119 @@
+package com.sparta.avengers.UnitTest.entity;
+
+import com.sparta.avengers.entity.Image;
+import com.sparta.avengers.entity.Board;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ImageTest {
+
+    @Nested
+    @DisplayName("이미지 DB저장 객체 생성")
+    class CreateImage{
+
+        private Board board;
+        private String imgURL;
+
+        @BeforeEach
+        void setup(){
+            board = Board.builder()
+                    .id(1L)
+                    .title("제목")
+                    .content("상세내용")
+                    .build();
+
+            imgURL="https://hosunghan.s3.ap-northeast-2.amazonaws.com/static/b9a68c15-31bb-42a8-8c18-bbfd96e89edf20220806_193636.jpg";
+        }
+
+        @Test
+        @DisplayName("정상케이스")
+        void createImage_Normal(){
+
+            //given -> setup()
+
+            //when
+            Image image = new Image(board,imgURL);
+
+            //then
+            assertEquals(board.getId(),image.getBoard().getId());
+            assertEquals(imgURL,image.getImgURL());
+
+
+        }
+
+        @Nested
+        @DisplayName("실패 케이스")
+        class FailCases{
+            @Nested
+            @DisplayName("BoardId")
+            class postId{
+                @Test
+                @DisplayName("null")
+                void failByNull(){
+                    //given
+                    board.setId(null);
+                    //when
+
+
+                    Exception exception = assertThrows(IllegalArgumentException.class , ()->{
+                        new Image(board,imgURL);
+                    });
+                    // then
+                    assertEquals("유효하지 않는 Board Id입니다.",exception.getMessage());
+                }
+                @Test
+                @DisplayName("minus")
+                void failByMinus(){
+
+                    //given
+                    board.setId(-1L);
+                    //when
+                    Exception exception = assertThrows(IllegalArgumentException.class , ()->{
+                        new Image(board,imgURL);
+                    });
+                    // then
+                    assertEquals("유효하지 않는 Post Id입니다.",exception.getMessage());
+                }
+            }
+
+            @Nested
+            @DisplayName("ImgUrl")
+            class ImgUrl{
+                @Test
+                @DisplayName("ImgUrl : null")
+                void failByUrl(){
+
+                    //given
+                    imgURL=null;
+
+                    //when
+                    Exception exception = assertThrows(IllegalArgumentException.class , ()->{
+                        new Image(board,imgURL);
+                    });
+                    //then
+                    assertEquals("imgUrl 이 유효하지 않습니다",exception.getMessage());
+                }
+
+                @Test
+                @DisplayName("ImgUrl : 포맷형태 틀림")
+                void failByUrlFormat(){
+
+                    imgURL="shopping-phinf.pstatic.net/main_2416122/24161228524.20200915151118.jpg";
+                    //when
+                    Exception exception = assertThrows(IllegalArgumentException.class , ()->{
+                        new Image(board,imgURL);
+                    });
+                    //then
+                    assertEquals("imgUrl 이 유효하지 않습니다",exception.getMessage());
+
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/test/java/com/sparta/avengers/UnitTest/service/S3UploaderServiceTest.java
+++ b/src/test/java/com/sparta/avengers/UnitTest/service/S3UploaderServiceTest.java
@@ -1,0 +1,103 @@
+package com.sparta.avengers.UnitTest.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.sparta.avengers.config.S3MockConfig;
+import com.sparta.avengers.service.S3UploaderService;
+import com.fasterxml.jackson.core.util.ByteArrayBuilder;
+import io.findify.s3mock.S3Mock;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import(S3MockConfig.class)
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+class S3UploaderServiceTest {
+
+
+    @Autowired
+    private AmazonS3Client amazonS3;
+
+    @Autowired
+    private S3UploaderService s3UploaderService;
+
+    @Autowired
+    private static final String BUCKET_NAME = "hosunghan";
+    private File file;
+    private final MultipartFile multipartFile = new MockMultipartFile(
+            "test1",
+            "test1.PNG",
+            MediaType.IMAGE_PNG_VALUE,
+            "test1".getBytes()
+    );
+
+    @BeforeEach
+    void setUp(@Autowired S3Mock s3Mock) throws IOException {
+
+        //가짜 S3 만들기 && 가짜 이미지 파일 만들기
+        s3Mock.start();
+        amazonS3.createBucket(BUCKET_NAME);
+        file = new File(multipartFile.getOriginalFilename());
+        multipartFile.transferTo(file);
+
+
+    }
+
+    @AfterEach
+    void shutDown(@Autowired S3Mock s3Mock) {
+        if(file.delete()){
+            System.out.println("file delete success");
+        }
+        else{
+            System.out.println("File delete fail");
+        }
+        amazonS3.shutdown();
+        s3Mock.stop();
+    }
+
+    @Nested
+    @DisplayName("이미지 S3 업로드 테스트")
+    class upload_success {
+
+        @Test
+        @DisplayName("성공")
+        void test() throws IOException {
+            //given 파일 업로드 한 상황
+            String test= s3UploaderService.putS3(file,multipartFile.getOriginalFilename());
+            System.out.println(test);
+//
+//            PutObjectRequest putObjectRequest = new PutObjectRequest(BUCKET_NAME,multipartFile.getOriginalFilename(),file)
+//                    .withCannedAcl(CannedAccessControlList.PublicRead);
+//            amazonS3.putObject(putObjectRequest);
+//            // when  업로드된 파일을 가져왔을 때,
+//            S3Object s3Object = amazonS3.getObject(BUCKET_NAME,multipartFile.getOriginalFilename());
+//
+//            //then 같은지 확인
+//            //assertThat(file.exists()).isEqualTo(true);
+//            assertThat(new String(FileCopyUtils.copyToByteArray(s3Object.getObjectContent()))).isEqualTo("test1");
+//
+
+
+        }
+    }
+
+}

--- a/src/test/java/com/sparta/avengers/UnitTest/validator/URLValidatorTest.java
+++ b/src/test/java/com/sparta/avengers/UnitTest/validator/URLValidatorTest.java
@@ -1,0 +1,65 @@
+package com.sparta.avengers.UnitTest.validator;
+
+import com.sparta.avengers.validator.URLvalidator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class URLValidatorTest {
+
+    private String imgUrl;
+
+    @Nested
+    @DisplayName("URL Success Test")
+    class UrlSuccesTest{
+
+        @Test
+        @DisplayName("Success case")
+        void success(){
+            imgUrl="https://shopping-phinf.pstatic.net/main_8232398/82323985017.4.jpg";
+            assertTrue( URLvalidator.isValidURL(imgUrl));
+        }
+    }
+
+    @Nested
+    @DisplayName("URL Fail Test")
+    class UrlFailTest{
+
+        @Test
+        @DisplayName("URL : Format error")
+        void failByFormat(){
+
+            imgUrl="https/";
+            //throws를 발생시킬 것이다!
+            assertThrows(IllegalArgumentException.class,()->{
+                URLvalidator.isValidURL(imgUrl);
+            });
+        }
+        @Test
+        @DisplayName("URL : NULL error")
+        void failByNull(){
+
+            imgUrl=null;
+            //throws를 발생시킬 것
+            assertThrows(IllegalArgumentException.class,()->{
+                URLvalidator.isValidURL(imgUrl);
+            });
+            //message 같은 것으로 올바른 메시지가 나오는지 확인할 수도 있다.
+        }
+
+        @Test
+        @DisplayName("URL : \"\" case ")
+        void failByNothing(){
+
+            imgUrl="";
+            //throws를 발생시킬 것이다!
+            assertThrows(IllegalArgumentException.class,()->{
+                URLvalidator.isValidURL(imgUrl);
+            });
+            //message 같은 것으로 올바른 메시지가 나오는지 확인할 수도 있다.
+        }
+    }
+}

--- a/src/test/java/com/sparta/avengers/config/S3MockConfig.java
+++ b/src/test/java/com/sparta/avengers/config/S3MockConfig.java
@@ -1,0 +1,41 @@
+package com.sparta.avengers.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import io.findify.s3mock.S3Mock;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+
+@TestConfiguration
+public class S3MockConfig {
+
+    @Bean(name = "s3Mock")
+    public S3Mock s3Mock(){
+        return  new S3Mock.Builder()
+                .withPort(8001)
+                .withInMemoryBackend()
+                .build();
+
+    }
+
+    @Primary
+    @Bean(name = "amazonS3", destroyMethod = "shutdown")
+    public AmazonS3Client amazonS3(){
+        AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+                new AwsClientBuilder.EndpointConfiguration("http://127.0.0.1:8001", Regions.AP_NORTHEAST_2.name());
+
+        AmazonS3Client s3Client =(AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withPathStyleAccessEnabled(true)
+                .withEndpointConfiguration(endpointConfiguration)
+                .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials())).build();
+        return s3Client;
+    }
+
+}


### PR DESCRIPTION
<h1>⚠︎ 요구사항</h1>

> <h3>(게시글에 들어갈) 이미지 업로드</h3>

- 게시글 작성 중 요청하는 플로우이며, 게시글당 1개의 이미지만 업로드 가능하다는 전제로 진행

- `200` AccessToken이 있고, 유효한 Token일 때(== 로그인 상태일 때)만 요청 가능하게 하기
[s3 객체 주소를 response로 반환하기 (이미지 url)]

- `Exception` Multipartfile로 이미지 파일을 받고, 파일 변환에 실패할 경우, ‘파일 변환에 실패했습니다’를 `200 정상 응답`으로 나타내기
***

> <h3>API종류</h3>

1.  이미지 조회 API
    - 게시글 조회 시 이미지 url 포함해서 response 하기
    
2. 이미지 등록 API
    - AccessToken이 있고, 유효한 Token일 때만 이미지 업로드 API 요청이 가능하도록 하기

***

<h1>✎ 풀이 과정</h1>

> <h3>폴더 구조</h3>
![폴더구조](https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FAxT4m%2FbtrK4UgQz82%2FGRrKzJqQStqNhigWGnuKa1%2Fimg.png)

- 게시판(Board) 내에 이미지를 업로드하는 기능을 만들었습니다.
- `Token`이 먼저 확인될 수 있도록 API 진입은 /board 를 거쳐갑니다.
- 이미지URL의 유효성을 판별합니다.
- `Scheduler`의 경우 임의로 생성하였기 때문에 merge 후 정리예정입니다.

```@PostMapping("/api/board/image")
    public ResponseDto<?> imageUpload(@RequestParam("image") MultipartFile multipartFile){

        return s3Uploader.getResponseDto(multipartFile);

    }

    @GetMapping("/api/board/test")
    public void test(){
        try{
            imageScheduler.deleteImage();
        }catch (Exception e){
            e.printStackTrace();
        }
```

***

<h1>✓ 추가 사항</h1>

 - merge 후에 본 기능이 예상대로 정상 작동되는지 확인 필요 (board클 래스를 필요로 하여 추후 테스트예정)
 - 해당 API 진입시 `Token` 검사 후 진입한다는 예상 시나리오의 확인 필요

***

<h1>⚑ 예상되는 결과</h1>

- S3버킷을 통해 업로드 후 URL생성
- API 내 URL 형태로 `POST` 요청 성공
- 게시글 작성시 단일 이미지 업로드
