### PR TITLE
1,4

### DIFF
--- a/src/main/java/com/sparta/avengers/account/controller/CommentController.java
+++ b/src/main/java/com/sparta/avengers/account/controller/CommentController.java
@@ -1,0 +1,49 @@
+package com.sparta.avengers.account.controller;
+
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.controller.request.CommentRequestDto;
+import com.example.intermediate.service.CommentService;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@RequiredArgsConstructor
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @RequestMapping(value = "/api/auth/comment", method = RequestMethod.POST)
+    public ResponseDto<?> createComment(@RequestBody CommentRequestDto requestDto,
+                                        HttpServletRequest request) {
+        return commentService.createComment(requestDto, request);
+    }
+
+    @RequestMapping(value = "/api/comment/{id}", method = RequestMethod.GET)
+    public ResponseDto<?> getAllComments(@PathVariable Long id) {
+
+        return commentService.getAllCommentsByPost(id);
+    }
+
+    @RequestMapping(value = "/api/auth/comment/{id}", method = RequestMethod.PUT)
+    public ResponseDto<?> updateComment(@PathVariable Long id, @RequestBody CommentRequestDto requestDto,
+                                        HttpServletRequest request) {
+        return commentService.updateComment(id, requestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/comment/{id}", method = RequestMethod.DELETE)
+    public ResponseDto<?> deleteComment(@PathVariable Long id,
+                                        HttpServletRequest request) {
+        return commentService.deleteComment(id, request);
+    }
+
+    @RequestMapping(value = "/api/auth/commentlike/{id}", method = RequestMethod.POST)
+    public ResponseDto<?> likeComment(@PathVariable Long id,
+                                      HttpServletRequest request) {
+        return commentService.likeComment(id, request);
+    }
+
+
+}

--- a/src/main/java/com/sparta/avengers/account/controller/MemberController.java
+++ b/src/main/java/com/sparta/avengers/account/controller/MemberController.java
@@ -1,0 +1,44 @@
+package com.sparta.avengers.account.controller;
+
+import com.example.intermediate.controller.request.LoginRequestDto;
+import com.example.intermediate.controller.request.MemberRequestDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.service.MemberService;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @RequestMapping(value = "/api/member/signup", method = RequestMethod.POST)
+    public ResponseDto<?> signup(@RequestBody @Valid MemberRequestDto requestDto) {
+
+        return memberService.createMember(requestDto);
+    }
+
+    @RequestMapping(value = "/api/member/login", method = RequestMethod.POST)
+    public ResponseDto<?> login(@RequestBody @Valid LoginRequestDto requestDto,
+                                HttpServletResponse response
+    ) {
+        return memberService.login(requestDto, response);
+    }
+
+//  @RequestMapping(value = "/api/auth/member/reissue", method = RequestMethod.POST)
+//  public ResponseDto<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+//    return memberService.reissue(request, response);
+//  }
+
+    @RequestMapping(value = "/api/auth/member/logout", method = RequestMethod.POST)
+    public ResponseDto<?> logout(HttpServletRequest request) {
+        return memberService.logout(request);
+    }
+}

--- a/src/main/java/com/sparta/avengers/account/controller/PostController.java
+++ b/src/main/java/com/sparta/avengers/account/controller/PostController.java
@@ -1,0 +1,57 @@
+package com.sparta.avengers.account.controller;
+
+import com.example.intermediate.controller.request.PostRequestDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.domain.Post;
+import com.example.intermediate.repository.PostRepository;
+import com.example.intermediate.service.FileUploadService;
+import com.example.intermediate.service.PostService;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class PostController {
+
+    private final PostService postService;
+    private final PostRepository postRepository;
+
+    @RequestMapping(value = "/api/auth/post", method = RequestMethod.POST)
+    public ResponseDto<?> createPost(@RequestPart MultipartFile multipartFile,@RequestPart PostRequestDto requestDto,
+                                     HttpServletRequest request) {
+        return postService.createPost(multipartFile, requestDto, request);
+    }
+
+    @RequestMapping(value = "/api/post/{id}", method = RequestMethod.GET)
+    public ResponseDto<?> getPost(@PathVariable Long id) {
+        return postService.getPost(id);
+    }
+
+    @RequestMapping(value = "/api/post", method = RequestMethod.GET)
+    public ResponseDto<?> getAllPosts() {
+        return postService.getAllPost();
+    }
+
+    @RequestMapping(value = "/api/auth/post/{id}", method = RequestMethod.PUT)
+    public ResponseDto<?> updatePost(@PathVariable Long id, @RequestBody PostRequestDto postRequestDto,
+                                     HttpServletRequest request) {
+        return postService.updatePost(id, postRequestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/post/{id}", method = RequestMethod.DELETE)
+    public ResponseDto<?> deletePost(@PathVariable Long id,
+                                     HttpServletRequest request) {
+        return postService.deletePost(id, request);
+    }
+
+    @RequestMapping(value = "/api/auth/postlike/{id}", method = RequestMethod.POST)
+    public ResponseDto<?> likePost(@PathVariable Long id,
+                                   HttpServletRequest request) {
+        return postService.likePost(id, request);
+    }
+
+}

--- a/src/main/java/com/sparta/avengers/account/controller/RecommentController.java
+++ b/src/main/java/com/sparta/avengers/account/controller/RecommentController.java
@@ -1,0 +1,44 @@
+package com.sparta.avengers.account.controller;
+
+import com.example.intermediate.controller.request.CommentRequestDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.service.CommentService;
+import com.example.intermediate.service.RecommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Validated
+@RequiredArgsConstructor
+@RestController
+public class RecommentController {
+
+
+    private final RecommentService recommentService;
+
+    @RequestMapping(value = "/api/auth/recomment", method = RequestMethod.POST)
+    public ResponseDto<?> createRecomment(@RequestBody CommentRequestDto requestDto,
+                                          HttpServletRequest request) {
+        return recommentService.createRecomment(requestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/recomment/{id}", method = RequestMethod.PUT)
+    public ResponseDto<?> updateComment(@PathVariable Long id, @RequestBody CommentRequestDto requestDto,
+                                        HttpServletRequest request) {
+        return recommentService.updateRecomment(id, requestDto, request);
+    }
+
+    @RequestMapping(value = "/api/auth/recomment/{id}", method = RequestMethod.DELETE)
+    public ResponseDto<?> deleteComment(@PathVariable Long id,
+                                        HttpServletRequest request) {
+        return recommentService.deleteRecomment(id, request);
+    }
+
+    @RequestMapping(value = "/api/auth/recommentlike/{id}", method = RequestMethod.POST)
+    public ResponseDto<?> likeRecomment(@PathVariable Long id,
+                                        HttpServletRequest request) {
+        return recommentService.likeRecomment(id, request);
+    }
+}

--- a/src/main/java/com/sparta/avengers/account/controller/domain/Comment.java
+++ b/src/main/java/com/sparta/avengers/account/controller/domain/Comment.java
@@ -1,0 +1,58 @@
+package com.sparta.avengers.account.controller.domain;
+
+import com.example.intermediate.controller.request.CommentRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Comment extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "post_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private com.example.intermediate.domain.Post post;
+
+    @OneToMany(mappedBy = "comment",fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<com.example.intermediate.domain.Recomment> recomments;
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private int likenum;
+
+    public void update(CommentRequestDto commentRequestDto) {
+        this.content = commentRequestDto.getContent();
+    }
+
+
+    public void pushLike()
+    {
+        this.likenum++;
+    }
+    public void pushDislike()
+    {
+        if(this.likenum>0)
+        {
+            this.likenum--;
+        }
+    }
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+}

--- a/src/main/java/com/sparta/avengers/account/controller/domain/Commentlike.java
+++ b/src/main/java/com/sparta/avengers/account/controller/domain/Commentlike.java
@@ -1,0 +1,33 @@
+package com.sparta.avengers.account.controller.domain;
+
+
+import javax.persistence.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Commentlike{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "comment_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment comment;
+
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+}

--- a/src/main/java/com/sparta/avengers/account/controller/domain/Member.java
+++ b/src/main/java/com/sparta/avengers/account/controller/domain/Member.java
@@ -1,0 +1,58 @@
+package com.sparta.avengers.account.controller.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.Hibernate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.Objects;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Member extends Timestamped  {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @OneToMany(mappedBy = "member",fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<com.example.intermediate.domain.Post> posts;
+
+    @Column(nullable = false)
+    @JsonIgnore
+    private String password;
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) {
+            return false;
+        }
+        Member member = (Member) o;
+        return id != null && Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+
+    public boolean validatePassword(PasswordEncoder passwordEncoder, String password) {
+        return passwordEncoder.matches(password, this.password);
+    }
+}

--- a/src/main/java/com/sparta/avengers/account/controller/domain/Post.java
+++ b/src/main/java/com/sparta/avengers/account/controller/domain/Post.java
@@ -1,0 +1,63 @@
+package com.sparta.avengers.account.controller.domain;
+
+import com.example.intermediate.controller.request.PostRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Post extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private int likenum;
+
+    @Column(nullable = false)
+    private String Url;
+    //post에 속한 comment들
+    //fetch는 읽어오기 전략, LAZY는 필요할 때(사용하는 구간에 트랜젝션), EAGER은 항상
+    @OneToMany(mappedBy = "post",fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    public void update(PostRequestDto postRequestDto) {
+        this.title = postRequestDto.getTitle();
+        this.content = postRequestDto.getContent();
+    }
+
+    public void pushLike()
+    {
+        this.likenum++;
+    }
+    public void pushDislike()
+    {
+        if(this.likenum>0)
+        {
+            this.likenum--;
+        }
+    }
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+
+}

--- a/src/main/java/com/sparta/avengers/account/controller/domain/Postlike.java
+++ b/src/main/java/com/sparta/avengers/account/controller/domain/Postlike.java
@@ -1,0 +1,33 @@
+package com.sparta.avengers.account.controller.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Postlike{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "post_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private com.example.intermediate.domain.Post post;
+
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+}

--- a/src/main/java/com/sparta/avengers/account/controller/domain/Recomment.java
+++ b/src/main/java/com/sparta/avengers/account/controller/domain/Recomment.java
@@ -1,0 +1,56 @@
+package com.sparta.avengers.account.controller.domain;
+
+
+import com.example.intermediate.controller.request.CommentRequestDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Recomment extends Timestamped{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "comment_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Comment comment;
+
+    @Column(nullable = false)
+    private String content;
+    @Column(nullable = false)
+    private int likenum;
+    public void update(CommentRequestDto commentRequestDto) {
+        this.content = commentRequestDto.getContent();
+    }
+    public void pushLike()
+    {
+        this.likenum++;
+    }
+    public void pushDislike()
+    {
+        if(this.likenum>0)
+        {
+            this.likenum--;
+        }
+    }
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+    public boolean validateComment(Comment comment){return !this.comment.equals(comment);}
+
+
+
+}

--- a/src/main/java/com/sparta/avengers/account/controller/domain/Recommentlike.java
+++ b/src/main/java/com/sparta/avengers/account/controller/domain/Recommentlike.java
@@ -1,0 +1,33 @@
+package com.sparta.avengers.account.controller.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Recommentlike{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "recomment_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private com.example.intermediate.domain.Recomment recomment;
+
+    public boolean validateMember(Member member) {
+        return !this.member.equals(member);
+    }
+}

--- a/src/main/java/com/sparta/avengers/account/controller/request/LoginRequestDto.java
+++ b/src/main/java/com/sparta/avengers/account/controller/request/LoginRequestDto.java
@@ -1,0 +1,20 @@
+package com.sparta.avengers.account.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequestDto {
+
+  @NotBlank
+  private String nickname;
+
+  @NotBlank
+  private String password;
+
+}

--- a/src/main/java/com/sparta/avengers/account/controller/request/TokenDto.java
+++ b/src/main/java/com/sparta/avengers/account/controller/request/TokenDto.java
@@ -1,0 +1,17 @@
+package com.sparta.avengers.account.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TokenDto {
+  private String grantType;
+  private String accessToken;
+  private String refreshToken;
+  private Long accessTokenExpiresIn;
+}

--- a/src/main/java/com/sparta/avengers/account/controller/response/PostController.java
+++ b/src/main/java/com/sparta/avengers/account/controller/response/PostController.java
@@ -1,0 +1,55 @@
+package com.sparta.avengers.account.controller.response;
+
+import com.example.intermediate.controller.request.PostRequestDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.service.PostService;
+import javax.servlet.http.HttpServletRequest;
+
+import com.sparta.avengers.account.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PostController<ResponseDto> {
+
+  private final PostService postService;
+
+  //POST
+  @RequestMapping(value = "/api/auth/post", method = RequestMethod.POST)
+  public ResponseDto<?> createPost(@RequestBody PostRequestDto requestDto,
+      HttpServletRequest request) {
+    return postService.createPost(requestDto, request);
+  }
+
+  //Get id
+  @RequestMapping(value = "/api/post/{id}", method = RequestMethod.GET)
+  public ResponseDto<?> getPost(@PathVariable Long id) {
+    return postService.getPost(id);
+  }
+
+  //Get
+  @RequestMapping(value = "/api/post", method = RequestMethod.GET)
+  public ResponseDto<?> getAllPosts() {
+    return postService.getAllPost();
+  }
+
+  //Put id
+  @RequestMapping(value = "/api/auth/post/{id}", method = RequestMethod.PUT)
+  public ResponseDto<?> updatePost(@PathVariable Long id, @RequestBody PostRequestDto postRequestDto,
+      HttpServletRequest request) {
+    return postService.updatePost(id, postRequestDto, request);
+  }
+
+  //Delete id
+  @RequestMapping(value = "/api/auth/post/{id}", method = RequestMethod.DELETE)
+  public ResponseDto<?> deletePost(@PathVariable Long id,
+      HttpServletRequest request) {
+    return postService.deletePost(id, request);
+  }
+
+}

--- a/src/main/java/com/sparta/avengers/account/repository/CommentlikeRepository.java
+++ b/src/main/java/com/sparta/avengers/account/repository/CommentlikeRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.avengers.account.repository;
+
+
+import com.example.intermediate.domain.Comment;
+import com.example.intermediate.domain.Commentlike;
+import com.example.intermediate.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentlikeRepository extends JpaRepository<Commentlike, Long> {
+    List<Commentlike> findAllByMember(Member member);
+    List<Commentlike> findAllByComment(Comment comment);
+
+}

--- a/src/main/java/com/sparta/avengers/account/repository/PostlikeRepository.java
+++ b/src/main/java/com/sparta/avengers/account/repository/PostlikeRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.avengers.account.repository;
+
+
+import com.example.intermediate.domain.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostlikeRepository extends JpaRepository<Postlike, Long> {
+    List<Postlike> findAllByMember(Member member);
+    List<Postlike> findAllByPost(Post post);
+
+}

--- a/src/main/java/com/sparta/avengers/account/repository/RecommentlikeRepository.java
+++ b/src/main/java/com/sparta/avengers/account/repository/RecommentlikeRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.avengers.account.repository;
+
+
+import com.example.intermediate.domain.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RecommentlikeRepository extends JpaRepository<Recommentlike, Long> {
+    List<Recommentlike> findAllByMember(Member member);
+    List<Recommentlike> findAllByRecomment(Recomment recomment);
+
+}

--- a/src/main/java/com/sparta/avengers/account/service/CommentService.java
+++ b/src/main/java/com/sparta/avengers/account/service/CommentService.java
@@ -1,0 +1,255 @@
+package com.sparta.avengers.account.service;
+
+import com.example.intermediate.controller.request.CommentRequestDto;
+import com.example.intermediate.controller.response.CommentResponseDto;
+import com.example.intermediate.controller.response.RecommentResponseDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.domain.*;
+import com.example.intermediate.jwt.TokenProvider;
+import com.example.intermediate.repository.CommentRepository;
+import com.example.intermediate.repository.CommentlikeRepository;
+import com.example.intermediate.repository.RecommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final CommentlikeRepository commentlikeRepository;
+
+    private final RecommentRepository recommentRepository;
+    private final TokenProvider tokenProvider;
+    private final PostService postService;
+
+    @Transactional
+    public ResponseDto<?> createComment(CommentRequestDto requestDto, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+        //멤버는 httprequest로온 토큰을 이용해 멤버 객체를 찾고 comment 앤티티에 특정 맴버 객체 추가, id 공유됨
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+        //post는 requestbody로 전달받은 postid로 post객체 찾아서 comment 앤티티에 추가해줌. 그 때 id 공유
+        Post post = postService.isPresentPost(requestDto.getPostId());
+        if (null == post) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+        Comment comment = Comment.builder()
+                .member(member)
+                .post(post)
+                .content(requestDto.getContent())
+                .likenum(0)
+                .build();
+        commentRepository.save(comment);
+        return ResponseDto.success(
+                CommentResponseDto.builder()
+                        .id(comment.getId())
+                        .author(comment.getMember().getNickname())
+                        .content(comment.getContent())
+                        .createdAt(comment.getCreatedAt())
+                        .modifiedAt(comment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ResponseDto<?> getAllCommentsByPost(Long Id) {
+        Post post = postService.isPresentPost(Id);
+        System.out.println(post);
+        if (null == post) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+        List<Comment> commentList = commentRepository.findAllByPost(post);
+        List<CommentResponseDto> commentResponseDtoList = new ArrayList<>();
+
+        for (Comment comment : commentList) {
+            commentResponseDtoList.add(
+                    CommentResponseDto.builder()
+                            .id(comment.getId())
+                            .author(comment.getMember().getNickname())
+                            .content(comment.getContent())
+                            .recommentResponseDtos(recommentByComment(comment,comment.getMember()))
+                            .createdAt(comment.getCreatedAt())
+                            .modifiedAt(comment.getModifiedAt())
+                            .build()
+            );
+        }
+        return ResponseDto.success(commentResponseDtoList);
+    }
+
+    @Transactional
+    public ResponseDto<?> updateComment(Long id, CommentRequestDto requestDto, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Post post = postService.isPresentPost(requestDto.getPostId());
+        if (null == post) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+        Comment comment = isPresentComment(id);
+        if (null == comment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 id 입니다.");
+        }
+
+        if (comment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+
+        comment.update(requestDto);
+        return ResponseDto.success(
+                CommentResponseDto.builder()
+                        .id(comment.getId())
+                        .author(comment.getMember().getNickname())
+                        .content(comment.getContent())
+                        .createdAt(comment.getCreatedAt())
+                        .modifiedAt(comment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ResponseDto<?> deleteComment(Long id, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Comment comment = isPresentComment(id);
+        if (null == comment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 id 입니다.");
+        }
+
+        if (comment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+
+        commentRepository.delete(comment);
+        return ResponseDto.success("success");
+    }
+
+    @Transactional(readOnly = true)
+    public Comment isPresentComment(Long id) {
+        Optional<Comment> optionalComment = commentRepository.findById(id);
+        return optionalComment.orElse(null);
+    }
+
+    @Transactional
+    public Member validateMember(HttpServletRequest request) {
+        if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+            return null;
+        }
+        return tokenProvider.getMemberFromAuthentication();
+    }
+
+    public List<RecommentResponseDto> recommentByComment(Comment comment,Member member)
+    {
+        List<Recomment> recommentList= recommentRepository.findAllByComment(comment);
+        List<RecommentResponseDto> recommentResponseDtos=new ArrayList<>();
+
+        for(Recomment recomment: recommentList)
+        {
+            recommentResponseDtos.add(
+                    RecommentResponseDto
+                            .builder()
+                            .id(recomment.getId())
+                            .author(member.getNickname())
+                            .content(recomment.getContent())
+                            .createdAt(recomment.getCreatedAt())
+                            .modifiedAt(recomment.getModifiedAt())
+                            .build()
+            );
+        }
+
+        return recommentResponseDtos;
+
+    }
+    @Transactional
+    public ResponseDto<?> likeComment(Long id, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+        Comment comment = isPresentComment(id);
+        if (null == comment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+
+        List<Commentlike> commentlikes=commentlikeRepository.findAllByComment(comment);
+        boolean check=false;
+        for(Commentlike commentlike:commentlikes)
+        {
+            if(commentlike.getMember().equals(member))
+            {
+                check=true;
+                System.out.println("이미 좋아요한 댓글입니다.");
+                comment.pushDislike();
+                commentlikeRepository.delete(commentlike);
+                break;
+            }
+        }
+        if(check==false)
+        {
+            comment.pushLike();
+            System.out.println("좋아요.");
+            Commentlike commentlike= Commentlike.builder()
+                    .member(member)
+                    .comment(comment)
+                    .build();
+            commentlikeRepository.save(commentlike);
+        }
+
+        return ResponseDto.success("Push 'like' button");
+    }
+
+
+}

--- a/src/main/java/com/sparta/avengers/account/service/MemberService.java
+++ b/src/main/java/com/sparta/avengers/account/service/MemberService.java
@@ -1,0 +1,135 @@
+package com.sparta.avengers.account.service;
+
+import com.example.intermediate.controller.request.LoginRequestDto;
+import com.example.intermediate.controller.request.MemberRequestDto;
+import com.example.intermediate.controller.request.TokenDto;
+import com.example.intermediate.controller.response.MemberResponseDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.domain.Member;
+import com.example.intermediate.jwt.TokenProvider;
+import com.example.intermediate.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    private final PasswordEncoder passwordEncoder;
+    //  private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public ResponseDto<?> createMember(MemberRequestDto requestDto) {
+        if (null != isPresentMember(requestDto.getNickname())) {
+            return ResponseDto.fail("DUPLICATED_NICKNAME",
+                    "중복된 닉네임 입니다.");
+        }
+
+        if (!requestDto.getPassword().equals(requestDto.getPasswordConfirm())) {
+            return ResponseDto.fail("PASSWORDS_NOT_MATCHED",
+                    "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+        }
+        System.out.println("sadfsadf");
+        Member member = Member.builder()
+                .nickname(requestDto.getNickname())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .build();
+        memberRepository.save(member);
+        return ResponseDto.success(
+                MemberResponseDto.builder()
+                        .id(member.getId())
+                        .nickname(member.getNickname())
+                        .createdAt(member.getCreatedAt())
+                        .modifiedAt(member.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ResponseDto<?> login(LoginRequestDto requestDto, HttpServletResponse response) {
+        Member member = isPresentMember(requestDto.getNickname());
+        if (null == member) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "사용자를 찾을 수 없습니다.");
+        }
+
+        if (!member.validatePassword(passwordEncoder, requestDto.getPassword())) {
+            return ResponseDto.fail("INVALID_MEMBER", "사용자를 찾을 수 없습니다.");
+        }
+
+//    UsernamePasswordAuthenticationToken authenticationToken =
+//        new UsernamePasswordAuthenticationToken(requestDto.getNickname(), requestDto.getPassword());
+//    Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        TokenDto tokenDto = tokenProvider.generateTokenDto(member);
+        tokenToHeaders(tokenDto, response);
+
+        return ResponseDto.success(
+                MemberResponseDto.builder()
+                        .id(member.getId())
+                        .nickname(member.getNickname())
+                        .createdAt(member.getCreatedAt())
+                        .modifiedAt(member.getModifiedAt())
+                        .build()
+        );
+    }
+
+//  @Transactional
+//  public ResponseDto<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+//    if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+//      return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+//    }
+//    Member member = tokenProvider.getMemberFromAuthentication();
+//    if (null == member) {
+//      return ResponseDto.fail("MEMBER_NOT_FOUND",
+//          "사용자를 찾을 수 없습니다.");
+//    }
+//
+//    Authentication authentication = tokenProvider.getAuthentication(request.getHeader("Access-Token"));
+//    RefreshToken refreshToken = tokenProvider.isPresentRefreshToken(member);
+//
+//    if (!refreshToken.getValue().equals(request.getHeader("Refresh-Token"))) {
+//      return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+//    }
+//
+//    TokenDto tokenDto = tokenProvider.generateTokenDto(member);
+//    refreshToken.updateValue(tokenDto.getRefreshToken());
+//    tokenToHeaders(tokenDto, response);
+//    return ResponseDto.success("success");
+//  }
+
+    public ResponseDto<?> logout(HttpServletRequest request) {
+        if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+        Member member = tokenProvider.getMemberFromAuthentication();
+        if (null == member) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "사용자를 찾을 수 없습니다.");
+        }
+
+        return tokenProvider.deleteRefreshToken(member);
+    }
+
+    @Transactional(readOnly = true)
+    public Member isPresentMember(String nickname) {
+        Optional<Member> optionalMember = memberRepository.findByNickname(nickname);
+        return optionalMember.orElse(null);
+    }
+
+    public void tokenToHeaders(TokenDto tokenDto, HttpServletResponse response) {
+        response.addHeader("Authorization", "Bearer " + tokenDto.getAccessToken());
+        response.addHeader("Refresh-Token", tokenDto.getRefreshToken());
+        response.addHeader("Access-Token-Expire-Time", tokenDto.getAccessTokenExpiresIn().toString());
+    }
+
+}

--- a/src/main/java/com/sparta/avengers/account/service/PostService.java
+++ b/src/main/java/com/sparta/avengers/account/service/PostService.java
@@ -1,0 +1,273 @@
+package com.sparta.avengers.account.service;
+
+import com.example.intermediate.controller.request.PostRequestDto;
+import com.example.intermediate.controller.response.CommentResponseDto;
+import com.example.intermediate.controller.response.PostResponseDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.domain.*;
+import com.example.intermediate.jwt.TokenProvider;
+import com.example.intermediate.repository.CommentRepository;
+import com.example.intermediate.repository.PostRepository;
+import com.example.intermediate.repository.PostlikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+  private final PostRepository postRepository;
+  private final CommentRepository commentRepository;
+  private final PostlikeRepository postlikeRepository;
+  private final FileUploadService fileUploadService;
+  private final TokenProvider tokenProvider;
+
+  @Transactional
+  public ResponseDto<?> createPost(MultipartFile multipartFile,PostRequestDto requestDto, HttpServletRequest request) {
+    if (null == request.getHeader("Refresh-Token")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+
+    if (null == request.getHeader("Authorization")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+
+    Member member = validateMember(request);//request로 온 토큰으로 멤버 객체 반환
+    if (null == member) {
+      return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+    }
+
+    Post post = Post.builder()
+            .title(requestDto.getTitle())
+            .content(requestDto.getContent())
+            .likenum(0)
+            .Url(fileUploadService.uploadImage(multipartFile))
+            .member(member)
+            .build();
+    postRepository.save(post);
+    return ResponseDto.success(
+            PostResponseDto.builder()
+                    .id(post.getId())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .author(post.getMember().getNickname())
+                    .Url(post.getUrl())
+                    .createdAt(post.getCreatedAt())
+                    .modifiedAt(post.getModifiedAt())
+                    .build()
+    );
+  }
+
+
+  @Transactional(readOnly = true)
+  public ResponseDto<?> getPost(Long id) {
+    Post post = isPresentPost(id);
+    if (null == post) {
+      return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+    }
+
+    List<Comment> commentList = commentRepository.findAllByPost(post);
+    List<CommentResponseDto> commentResponseDtoList = new ArrayList<>();
+
+    for (Comment comment : commentList) {
+      commentResponseDtoList.add(
+              CommentResponseDto.builder()
+                      .id(comment.getId())
+                      .author(comment.getMember().getNickname())
+                      .content(comment.getContent())
+                      .createdAt(comment.getCreatedAt())
+                      .modifiedAt(comment.getModifiedAt())
+                      .build()
+      );
+    }
+
+    return ResponseDto.success(
+            PostResponseDto.builder()
+                    .id(post.getId())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .commentResponseDtoList(commentResponseDtoList)
+                    .author(post.getMember().getNickname())
+                    .createdAt(post.getCreatedAt())
+                    .modifiedAt(post.getModifiedAt())
+                    .build()
+    );
+  }
+
+  @Transactional(readOnly = true)
+  public ResponseDto<?> getAllPost() {
+    List<Post> postList = postRepository.findAllByOrderByModifiedAtDesc();
+    List<PostResponseDto> responseDtos = new ArrayList<PostResponseDto>();
+    for (Post post : postList) {
+      responseDtos.add(
+              PostResponseDto.builder()
+                      .id(post.getId())
+                      .title(post.getTitle())
+                      .content(post.getContent())
+                      .author(post.getMember().getNickname())
+                      .commentResponseDtoList(commentByPost(post,post.getMember()))
+                      .createdAt(post.getCreatedAt())
+                      .modifiedAt(post.getModifiedAt())
+                      .build()
+      );
+    }
+    return ResponseDto.success(responseDtos);
+  }
+
+  @Transactional
+  public ResponseDto<Post> updatePost(Long id, PostRequestDto requestDto, HttpServletRequest request) {
+    if (null == request.getHeader("Refresh-Token")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+
+    if (null == request.getHeader("Authorization")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+
+    Member member = validateMember(request);
+    if (null == member) {
+      return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+    }
+
+    Post post = isPresentPost(id);
+    if (null == post) {
+      return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+    }
+
+    if (post.validateMember(member)) {
+      return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+    }
+
+    post.update(requestDto);
+    return ResponseDto.success(post);
+  }
+
+  @Transactional
+  public ResponseDto<?> deletePost(Long id, HttpServletRequest request) {
+    if (null == request.getHeader("Refresh-Token")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+
+    if (null == request.getHeader("Authorization")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+
+    Member member = validateMember(request);
+    if (null == member) {
+      return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+    }
+
+    Post post = isPresentPost(id);
+    if (null == post) {
+      return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+    }
+
+    if (post.validateMember(member)) {
+      return ResponseDto.fail("BAD_REQUEST", "작성자만 삭제할 수 있습니다.");
+    }
+
+    postRepository.delete(post);
+    return ResponseDto.success("delete success");
+  }
+
+  @Transactional(readOnly = true)
+  public Post isPresentPost(Long id) {
+    Optional<Post> optionalPost = postRepository.findById(id);
+    return optionalPost.orElse(null);
+  }
+
+  @Transactional
+  public Member validateMember(HttpServletRequest request) {
+    if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+      return null;
+    }
+    return tokenProvider.getMemberFromAuthentication();
+  }
+
+  public List<CommentResponseDto> commentByPost(Post post, Member member)
+  {
+    List<Comment> commentList= commentRepository.findAllByPost(post);
+    List<CommentResponseDto> commentResponseDtos=new ArrayList<>();
+
+    for(Comment comment: commentList)
+    {
+      commentResponseDtos.add(
+              CommentResponseDto
+                      .builder()
+                      .id(comment.getId())
+                      .author(member.getNickname())
+                      .content(comment.getContent())
+                      .createdAt(comment.getCreatedAt())
+                      .modifiedAt(comment.getModifiedAt())
+                      .build()
+      );
+    }
+
+    return commentResponseDtos;
+
+  }
+
+  @Transactional
+  public ResponseDto<?> likePost(Long id, HttpServletRequest request) {
+    if (null == request.getHeader("Refresh-Token")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+    if (null == request.getHeader("Authorization")) {
+      return ResponseDto.fail("MEMBER_NOT_FOUND",
+              "로그인이 필요합니다.");
+    }
+    Member member = validateMember(request);
+    if (null == member) {
+      return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+    }
+    Post post = isPresentPost(id);
+    if (null == post) {
+      return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+    }
+
+
+    List<Postlike> postlikes=postlikeRepository.findAllByPost(post);
+    boolean check=false;
+    for(Postlike postlike:postlikes)
+    {
+      if(postlike.getMember().equals(member))
+      {
+        check=true;
+        System.out.println("이미 좋아요한 게시물입니다.");
+        post.pushDislike();
+        postlikeRepository.delete(postlike);
+        break;
+      }
+    }
+    if(check==false)
+    {
+      post.pushLike();
+      System.out.println("좋아요.");
+      Postlike postlike= Postlike.builder()
+              .member(member)
+              .post(post)
+              .build();
+      postlikeRepository.save(postlike);
+    }
+
+    return ResponseDto.success("Push 'like' button");
+  }
+
+
+
+
+}

--- a/src/main/java/com/sparta/avengers/account/service/RecommentService.java
+++ b/src/main/java/com/sparta/avengers/account/service/RecommentService.java
@@ -1,0 +1,225 @@
+package com.sparta.avengers.account.service;
+
+import com.example.intermediate.controller.request.CommentRequestDto;
+import com.example.intermediate.controller.response.CommentResponseDto;
+import com.example.intermediate.controller.response.ResponseDto;
+import com.example.intermediate.domain.*;
+import com.example.intermediate.jwt.TokenProvider;
+import com.example.intermediate.repository.RecommentRepository;
+import com.example.intermediate.repository.RecommentlikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RecommentService {
+
+    private final RecommentRepository recommentRepository;
+    private final RecommentlikeRepository recommentlikeRepository;
+    private final CommentService commentService;
+    private final TokenProvider tokenProvider;
+
+
+    @Transactional
+    public ResponseDto<?> createRecomment(CommentRequestDto requestDto, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+        //멤버는 httprequest로온 토큰을 이용해 멤버 객체를 찾고 comment 앤티티에 특정 맴버 객체 추가, id 공유됨
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+        //comment는 requestbody로 전달받은 commentid로 comment객체 찾아서 recomment 앤티티에 추가해줌. 그 때 id 공유
+        Comment comment = commentService.isPresentComment(requestDto.getCommentId());
+
+
+        if (null == comment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 코멘트입니다.");
+        }
+
+        Recomment recomment = Recomment.builder()
+                .member(member)
+                .comment(comment)
+                .content(requestDto.getContent())
+                .likenum(0)
+                .build();
+
+        recommentRepository.save(recomment);
+        return ResponseDto.success(
+                CommentResponseDto.builder()
+                        .id(recomment.getId())
+                        .author(recomment.getMember().getNickname())
+                        .content(recomment.getContent())
+                        .createdAt(recomment.getCreatedAt())
+                        .modifiedAt(recomment.getModifiedAt())
+                        .build()
+        );
+    }
+
+
+
+
+
+    /*@Transactional(readOnly = true)
+    public ResponseDto<?> getAllCommentsByPost(Long postId) {
+        Post post = postService.isPresentPost(postId);
+        if (null == post) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+        List<Comment> commentList = commentRepository.findAllByPost(post);
+        List<CommentResponseDto> commentResponseDtoList = new ArrayList<>();
+        for (Comment comment : commentList) {
+            commentResponseDtoList.add(
+                    CommentResponseDto.builder()
+                            .id(comment.getId())
+                            .author(comment.getMember().getNickname())
+                            .content(comment.getContent())
+                            .createdAt(comment.getCreatedAt())
+                            .modifiedAt(comment.getModifiedAt())
+                            .build()
+            );
+        }
+        return ResponseDto.success(commentResponseDtoList);
+    }*/
+
+    @Transactional
+    public ResponseDto<?> updateRecomment(Long id, CommentRequestDto requestDto, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+
+        Recomment recomment = isPresentRecomment(id);
+        if (null == recomment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 번호 입니다.");
+        }
+
+        if (recomment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+
+        recomment.update(requestDto);
+        return ResponseDto.success(
+                CommentResponseDto.builder()
+                        .id(recomment.getId())
+                        .author(recomment.getMember().getNickname())
+                        .content(recomment.getContent())
+                        .createdAt(recomment.getCreatedAt())
+                        .modifiedAt(recomment.getModifiedAt())
+                        .build()
+        );
+    }
+
+    @Transactional
+    public ResponseDto<?> deleteRecomment(Long id, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+
+        Recomment recomment = isPresentRecomment(id);
+        if (null == recomment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 댓글 id 입니다.");
+        }
+
+        if (recomment.validateMember(member)) {
+            return ResponseDto.fail("BAD_REQUEST", "작성자만 수정할 수 있습니다.");
+        }
+
+        recommentRepository.delete(recomment);
+        return ResponseDto.success("success");
+    }
+
+    @Transactional(readOnly = true)
+    public Recomment isPresentRecomment(Long id) {
+        Optional<Recomment> optionalRecomment = recommentRepository.findById(id);
+        return optionalRecomment.orElse(null);
+    }
+
+    @Transactional
+    public Member validateMember(HttpServletRequest request) {
+        if (!tokenProvider.validateToken(request.getHeader("Refresh-Token"))) {
+            return null;
+        }
+        return tokenProvider.getMemberFromAuthentication();
+    }
+    @Transactional
+    public ResponseDto<?> likeRecomment(Long id, HttpServletRequest request) {
+        if (null == request.getHeader("Refresh-Token")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+        if (null == request.getHeader("Authorization")) {
+            return ResponseDto.fail("MEMBER_NOT_FOUND",
+                    "로그인이 필요합니다.");
+        }
+        Member member = validateMember(request);
+        if (null == member) {
+            return ResponseDto.fail("INVALID_TOKEN", "Token이 유효하지 않습니다.");
+        }
+        Recomment recomment = isPresentRecomment(id);
+        if (null == recomment) {
+            return ResponseDto.fail("NOT_FOUND", "존재하지 않는 게시글 id 입니다.");
+        }
+
+
+        List<Recommentlike> recommentlikes=recommentlikeRepository.findAllByRecomment(recomment);
+        boolean check=false;
+        for(Recommentlike recommentlike:recommentlikes)
+        {
+            if(recommentlike.getMember().equals(member))
+            {
+                check=true;
+                System.out.println("이미 좋아요한 게시물입니다.");
+                recomment.pushDislike();
+                recommentlikeRepository.delete(recommentlike);
+                break;
+            }
+        }
+        if(check==false)
+        {
+            recomment.pushLike();
+            System.out.println("좋아요.");
+            Recommentlike recommentlike= Recommentlike.builder()
+                    .member(member)
+                    .recomment(recomment)
+                    .build();
+            recommentlikeRepository.save(recommentlike);
+        }
+
+        return ResponseDto.success("Push 'like' button");
+    }
+}


### PR DESCRIPTION
기능 1, 4를 구현하였습니다. 
### 기능1

- **게시글 좋아요 기능 및 댓글/대댓글 좋아요**
    - **`200`** AccessToken이 있고, 유효한 Token일 때(== 로그인 상태일 때)만 좋아요 가능하게 하기
    - **`Exception`** AccessToken이 없거나, 유효하지 않은 Token일 때 ‘로그인이 필요합니다.’를 200 정상 응답으로 나타내기
    - 게시글 목록 response에 id, 제목, 작성자, 좋아요 개수, 대댓글 제외한 댓글 개수, 등록일, 수정일 나타내기
    - **API 종류**
        1.  좋아요 등록 API
            - AccessToken이 있고, 유효한 Token일 때만 요청 가능하도록 하기
            - 게시글, 댓글, 대댓글 reponse에 좋아요 개수 함께 나타내기
        2. 좋아요 취소 API
            - AccessToken이 있고, 유효한 Token일 때만 요청 가능하도록 하기
            - 게시글, 댓글, 대댓글 reponse에 좋아요 개수 함께 나타내기

### 기능4

- **게시글**
    - 이미지 업로드 후, 받아온 response의 imgUrl을 포함하여 글 제목,내용,이미지 주소를 함께 업로드한다.
    - **`200`** AccessToken이 있고, 유효한 Token일 때(== 로그인 상태일 때)만 요청 가능하게 하기
    - **`Exception`** 해당 게시글 조회 시, 존재하지 않는 게시글 id 일 때, ‘존재하지 않는 게시글 입니다.’를 200 정상 응답으로 나타내기
    - API 종류
        1. 전체 게시글 목록 조회 API
        2. 게시글 하나 조회 API
        3. 게시글 작성 API
        4. 게시글 수정 API
        5. 게시글 삭제 API